### PR TITLE
Allow SII compliance without forking

### DIFF
--- a/signxml/util/__init__.py
+++ b/signxml/util/__init__.py
@@ -114,7 +114,7 @@ class DERSequenceOfIntegers(univ.SequenceOf):
 class Namespace(dict):
     __getattr__ = dict.__getitem__
 
-class XMLProcessor:
+class XMLProcessor(object):
     _schema, _default_parser = None, None
 
     @classmethod


### PR DESCRIPTION
Fixes #64. #52 could probably be considered fixed by this as well.

List of changes:
- XMLSigner gains a new method, key_value_serialization_is_required(), which
  may be overriden in subclasses to force key value serialization regardless of
  the existence of a certificate chain.
- The C14N algorithm transform is generated regardless of the signing method.
- XMLProcessor becomes a new-style class.

These changes make it possible to define an SII-compliant XMLSigner subclass as
follows:

```
from signxml import methods, XMLSigner

class Signer(XMLSigner):

    def __init__(self):
        super(Signer, self).__init__(
            method=methods.detached,
            signature_algorithm='rsa-sha1',
            digest_algorithm='sha1',
            c14n_algorithm='http://www.w3.org/TR/2001/REC-xml-c14n-20010315')

    def key_value_serialization_is_required(self, cert_chain):
        return True
```
