### PR TITLE
Allow newer version of eight library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'lxml >= 3.5.0, < 3.7',
         'defusedxml >= 0.4.1, < 0.6',
-        'eight >= 0.3.0, < 0.4',
+        'eight >= 0.3.0, < 0.5',
         'cryptography >= 1.2.3, < 1.8',
         'pyOpenSSL >= 0.15.1, < 17',
         'certifi >= 2015.11.20.1'


### PR DESCRIPTION
This PR allows signxml to use newer versions of the eight library (including the one you just released). The eight library did not substantially changed between 0.3.3 and 0.4.1, and 0.4.1 is needed due to kislyuk/eight#4 being needed for Python 3 compatibility (the AttributeError thing is more strictly enforced in Python 3).