### PR TITLE
Allow newer versions of several requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ setup(
     description='Python XML Signature library',
     long_description=open('README.rst').read(),
     install_requires=[
-        'lxml >= 3.5.0, < 3.7',
+        'lxml >= 3.5.0, < 3.8',
         'defusedxml >= 0.4.1, < 0.6',
         'eight >= 0.3.0, < 0.5',
-        'cryptography >= 1.2.3, < 1.8',
-        'pyOpenSSL >= 0.15.1, < 17',
+        'cryptography >= 1.2.3, < 1.9',
+        'pyOpenSSL >= 0.15.1, < 18',
         'certifi >= 2015.11.20.1'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'lxml >= 3.5.0, < 3.8',
         'defusedxml >= 0.4.1, < 0.6',
         'eight >= 0.3.0, < 0.5',
-        'cryptography >= 1.2.3, < 1.9',
+        'cryptography >= 1.2.3, < 1.8',
         'pyOpenSSL >= 0.15.1, < 18',
         'certifi >= 2015.11.20.1'
     ],


### PR DESCRIPTION
signxml is pinning the max version of several requirements of libraries that have all updated past the max version. This PR upgrades them all.

For a library used in other projects, it may be advisable to remove the max version and let the library user themselves manage the max versions in their own requirements files (and let the library user deal with the conflicts themselves; they're smart enough to figure it out). This will get rid of the need for the PR every time a library upgrades in backwards compatible ways.