### PR TITLE
Use asn1crypto instead of pyasn1 to match cryptography lib

### DIFF
--- a/Changes.rst
+++ b/Changes.rst
@@ -1,4 +1,6 @@
-
+Changes for v2.3.0 (2017-??-??)
+===============================
+-  Replace pyasn1 with asn1crypto to match cryptography library
 
 Changes for v2.2.4 (2017-03-19)
 ===============================

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='signxml',
-    version="2.2.6",
+    version="2.3.0",
     url='https://github.com/kislyuk/signxml',
     license='Apache Software License',
     author='Andrey Kislyuk',
@@ -15,7 +15,7 @@ setup(
         'lxml >= 3.5.0, < 4',
         'defusedxml >= 0.4.1, < 0.6',
         'eight >= 0.3.0, < 0.5',
-        'cryptography >= 1.2.3, < 1.8',
+        'cryptography >= 1.8, < 1.9',
         'pyOpenSSL >= 0.15.1, < 18',
         'certifi >= 2015.11.20.1'
     ],

--- a/signxml/util/__init__.py
+++ b/signxml/util/__init__.py
@@ -13,7 +13,6 @@ from base64 import b64encode, b64decode
 from eight import str, bytes
 from lxml import etree
 from defusedxml.lxml import fromstring
-from pyasn1.type import univ
 
 from ..exceptions import RedundantCert, InvalidCertificate
 
@@ -106,13 +105,6 @@ def add_pem_header(bare_base64_cert):
 def iterate_pem(certs):
     for match in re.findall(pem_regexp, ensure_str(certs)):
         yield match
-
-class DERSequenceOfIntegers(univ.SequenceOf):
-    componentType = univ.Integer()
-    def __init__(self, integers):
-        univ.SequenceOf.__init__(self)
-        for pos, i in enumerate(integers):
-            self.setComponentByPosition(pos, i)
 
 class Namespace(dict):
     __getattr__ = dict.__getitem__


### PR DESCRIPTION
This PR replaces pyasn1 with asn1crypto, just as the cryptography library has done. It uses a similar substitution as https://github.com/pyca/cryptography/pull/3361/files#diff-943ffbce399c77d88f98cb3cd9cdc82dR49 does for replacing encode, and goes one step further using from_p1363() in https://github.com/wbond/asn1crypto/blob/master/asn1crypto/algos.py#L531 which already does all the byte splitting that was performed in the code.