### PR TITLE
Remove use of Exception.message for py3 compatibility. Closes #36

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -728,7 +728,7 @@ class XMLVerifier(XMLSignatureProcessor):
                 verify(signing_cert, raw_signature, signed_info_c14n, signature_digest_method)
             except OpenSSLCryptoError as e:
                 try:
-                    lib, func, reason = e.message[0]
+                    lib, func, reason = e.args[0][0]
                 except Exception:
                     reason = e
                 raise InvalidSignature("Signature verification failed: {}".format(reason))


### PR DESCRIPTION
The DeprecationWarning from #36 is actually problematic, since Python 3 has removed the "message" attribute of Exceptions. The fix from #42 masked this Python 3 incompatibility by just catching an overly broad Exception base class. This PR replaces the use of .message with .args[0] as seen in <http://stackoverflow.com/questions/1272138/baseexception-message-deprecated-in-python-2-6>. 