### PR TITLE
Add explicit dependency on asn1crypto to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'defusedxml >= 0.4.1, < 0.6',
         'eight >= 0.3.0, < 0.5',
         'cryptography >= 1.8, < 1.9',
+        'asn1crypto >= 0.21.0',
         'pyOpenSSL >= 0.15.1, < 18',
         'certifi >= 2015.11.20.1'
     ],


### PR DESCRIPTION
Because the code is directly using asn1crypto library in addition to the cryptography library, this PR adds an explicit dependency on asn1crypto in the setup.py. It uses the same version restriction inside https://github.com/pyca/cryptography/blob/1.8.1/setup.py#L38 .

Also, a new version release on PyPI would be appreciated once PRs are all sorted out.