### PR TITLE
Allow newer versions of cryptography library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'lxml >= 3.5.0, < 4',
         'defusedxml >= 0.4.1, < 0.6',
         'eight >= 0.3.0, < 0.5',
-        'cryptography >= 1.8, < 1.9',
+        'cryptography >= 1.8, < 1.10',
         'asn1crypto >= 0.21.0',
         'pyOpenSSL >= 0.15.1, < 18',
         'certifi >= 2015.11.20.1'


### PR DESCRIPTION
For projects that use both signxml and pyopenssl, https://github.com/pyca/pyopenssl/pull/612 made an incompatible requirements change for the cryptography library; pyopenssl requires a version >= 1.9, while signxml requires <1.9. This PR increases the maximum allowed version for signxml to allow version 1.9 up to (but not including) 1.10/2.0.