### PR TITLE
Allow newer cryptography versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
         virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
         source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
       fi
+  - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update; fi
   - if [[ $TRAVIS_OS_NAME == osx ]]; then brew install openssl; fi
   - if [[ $TRAVIS_OS_NAME == osx ]]; then export LDFLAGS="-L$(brew --prefix openssl)/lib" CFLAGS="-I$(brew --prefix openssl)/include"; fi
   - pip install --upgrade pip virtualenv

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'lxml >= 3.5.0, < 4',
         'defusedxml >= 0.4.1, < 0.6',
         'eight >= 0.3.0, < 0.5',
-        'cryptography >= 1.8, < 1.10',
+        'cryptography >= 1.8, < 2.1',
         'asn1crypto >= 0.21.0',
         'pyOpenSSL >= 0.15.1, < 18',
         'certifi >= 2015.11.20.1'


### PR DESCRIPTION
cryptography >=2.0 now ships a manylinux1 wheel with all dependencies included. This significantly reduces the installation overhead for most environments.