### PR TITLE
Allow URI attribute of Reference to be absent

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -223,7 +223,7 @@ class XMLSignatureProcessor(XMLProcessor):
 
     def _resolve_reference(self, doc_root, reference, uri_resolver=None):
         uri = reference.get("URI")
-        if uri == "":
+        if not uri:
             return doc_root
         elif uri.startswith("#xpointer("):
             raise InvalidInput("XPointer references are not supported")


### PR DESCRIPTION
The schema and standard allow for the absence of the URI attribute of
the <ds:Reference> element. For example the signed XML files that
oath-toolkit produces are missing this attribute.