### PR TITLE
Add missing c14n transform in enveloping and detached methods

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -470,20 +470,22 @@ class XMLSigner(XMLSignatureProcessor):
 
     def _build_sig(self, sig_root, reference_uris, c14n_inputs):
         signed_info = SubElement(sig_root, ds_tag("SignedInfo"), nsmap=self.namespaces)
-        c14n_method = SubElement(signed_info, ds_tag("CanonicalizationMethod"), Algorithm=self.c14n_alg)
+        SubElement(signed_info, ds_tag("CanonicalizationMethod"), Algorithm=self.c14n_alg)
         if self.sign_alg.startswith("hmac-"):
             algorithm_id = self.known_hmac_digest_tags[self.sign_alg]
         else:
             algorithm_id = self.known_signature_digest_tags[self.sign_alg]
-        signature_method = SubElement(signed_info, ds_tag("SignatureMethod"), Algorithm=algorithm_id)
+        SubElement(signed_info, ds_tag("SignatureMethod"), Algorithm=algorithm_id)
         for i, reference_uri in enumerate(reference_uris):
             reference = SubElement(signed_info, ds_tag("Reference"), URI=reference_uri)
+            transforms = SubElement(reference, ds_tag("Transforms"))
             if self.method == methods.enveloped:
-                transforms = SubElement(reference, ds_tag("Transforms"))
                 SubElement(transforms, ds_tag("Transform"), Algorithm=namespaces.ds + "enveloped-signature")
                 SubElement(transforms, ds_tag("Transform"), Algorithm=self.c14n_alg)
-            digest_method = SubElement(reference, ds_tag("DigestMethod"),
-                                       Algorithm=self.known_digest_tags[self.digest_alg])
+            else:
+                SubElement(transforms, ds_tag("Transform"), Algorithm=self.c14n_alg)
+
+            SubElement(reference, ds_tag("DigestMethod"), Algorithm=self.known_digest_tags[self.digest_alg])
             digest_value = SubElement(reference, ds_tag("DigestValue"))
             payload_c14n = self._c14n(c14n_inputs[i], algorithm=self.c14n_alg)
             digest = self._get_digest(payload_c14n, self._get_digest_method_by_tag(self.digest_alg))


### PR DESCRIPTION
We experienced some issues when trying to call a sapXI endpoint, it seems when using a BinarySecurityToken using http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0.pdf the c14n transform is missing, which in our case leads to responses like the one below (for reference):

```
Reason : com.sap.aii.security.lib.exception.SecurityException: SecurityException in method: verify( Message, byte[], CPALookupObject ). Message: SecurityException in method: verify( Message, byte[], CPALookupObject ). WSSEThread-Exception: SecurityException in method: run(). Message: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.. To-String: com.sap.security.core.policy.exceptions.VerifyException: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.; To-String: com.sap.aii.security.lib.exception.SecurityException: SecurityException in method: run(). Message: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.. To-String: com.sap.security.core.policy.exceptions.VerifyException: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.. To-String: com.sap.aii.security.lib.exception.SecurityException: SecurityException in method: verify( Message, byte[], CPALookupObject ). WSSEThread-Exception: SecurityException in method: run(). Message: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.. To-String: com.sap.security.core.policy.exceptions.VerifyException: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.; To-String: com.sap.aii.security.lib.exception.SecurityException: SecurityException in method: run(). Message: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.. To-String: com.sap.security.core.policy.exceptions.VerifyException: [com.sap.ASJ.wssec.030197] Error while valdiating the digital signature. The error was java.lang.NullPointerException while trying to invoke the method com.sap.engine.lib.xml.signature.elements.Reference.getURI() of a null object loaded from an array (which itself was loaded from local variable 'ref') with an index loaded from local variable 'i'.See log trace with id: n/a
```

Without the message xml, our code looks approx like:

```
wsse_key = lxml.etree.Element('{http://www.w3.org/2000/09/xmldsig#}KeyInfo')
wsse_key_token = lxml.etree.SubElement(wsse_key, '{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}SecurityTokenReference')
wsse_key_ref = lxml.etree.SubElement(wsse_key_token, '{http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd}Reference')
wsse_key_ref.set('URI', '#myref')

signer = signxml.XMLSigner(method=signxml.methods.detached, signature_algorithm="rsa-sha1",
                           digest_algorithm='sha1',
                           c14n_algorithm="http://www.w3.org/2001/10/xml-exc-c14n#")\

signature = signer.sign(message_envelope,
                        key=signer_key, cert=signer_cert,
                        reference_uri=['#wsuid-body-....',
                                       '#wsu-targetID-....'],
                        key_info=wsse_key)

```

