### PR TITLE
Apply transforms and digest calculations to copies of root. Closes #125.

### DIFF
--- a/test/example-125.xml
+++ b/test/example-125.xml
@@ -1,0 +1,72 @@
+<data xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <!-- This comment is very important! -->
+    <country name="Liechtenstein">
+        <rank>1</rank>
+        <year>2008</year>
+        <gdppc>141100</gdppc>
+        <neighbor name="Austria" direction="E"/>
+        <neighbor name="Switzerland" direction="W"/>
+    </country>
+    <security>
+      <ds:Signature><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2006/12/xml-c14n11"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><ds:Reference URI=""><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2006/12/xml-c14n11"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>IJ6AgD9qczSIQ3rvT0oCZC4P34fhv8Rq8a2Xq4Ia7sU=</ds:DigestValue></ds:Reference><ds:Reference URI="#object-1"><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>b0/tr1PjTGLb/E6GyuPeW+iWHA2vd/qAfuPDXCuu1nM=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>O81+oTSSzlTgSD2uv7HnbZ0pyXa1QXdk/iO+ddRvChjACJvAFYR8l3oYV4BW3BxtOVc5HrfoygvYj8a44HNTFWdafAY2xWju7ffeasSrE/NwVl/B/GFZpVBKAwiDutl+Fir2OqIWZ3q2oY45ecxIxVaOpuKpWYb8qR8QOa5RrOo=</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIEUTCCA7qgAwIBAgIBATANBgkqhkiG9w0BAQUFADCBrDELMAkGA1UEBhMCVVMx
+CzAJBgNVBAgTAkNBMRUwEwYDVQQHEwxNb3VudGFpblZpZXcxETAPBgNVBAoTCERO
+QW5leHVzMRMwEQYDVQQLEwpPcGVyYXRpb25zMRQwEgYDVQQDEwtETkFuZXh1cyBD
+QTEZMBcGA1UEKRMQRE5BbmV4dXNQbGF0Zm9ybTEgMB4GCSqGSIb3DQEJARYRaW5m
+b0BkbmFuZXh1cy5jb20wHhcNMTQwOTE1MDIwNjM3WhcNMjQwOTEyMDIwNjM3WjCB
+rjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRUwEwYDVQQHEwxNb3VudGFpblZp
+ZXcxETAPBgNVBAoTCEROQW5leHVzMRMwEQYDVQQLEwpPcGVyYXRpb25zMRYwFAYD
+VQQDFA0qLmV4YW1wbGUuY29tMRkwFwYDVQQpExBETkFuZXh1c1BsYXRmb3JtMSAw
+HgYJKoZIhvcNAQkBFhFpbmZvQGRuYW5leHVzLmNvbTCBnzANBgkqhkiG9w0BAQEF
+AAOBjQAwgYkCgYEAvbCY1tXqnjH8gFfY8FDcBM4xXV43NOPp1eJ7Ke+z0PS5m8AO
+w2i75LwtPx0Mn7itLpfB6x95kVkQbS1PXb/C/8FPdBqMLZGChzO+ZW7i5Nl6Ckdf
+5QqumJcOObBqs0N1DQ/765gWZaUy2Yycl/xYlpY43R4m9zaDdirz+jGrsQkCAwEA
+AaOCAX0wggF5MAkGA1UdEwQCMAAwEQYJYIZIAYb4QgEBBAQDAgZAMDQGCWCGSAGG
++EIBDQQnFiVFYXN5LVJTQSBHZW5lcmF0ZWQgU2VydmVyIENlcnRpZmljYXRlMB0G
+A1UdDgQWBBRlDO8LQtZo/K38JQ2RLrh6uL43NTCB4QYDVR0jBIHZMIHWgBSvoZrl
+dd3E70KF+jxbiTuu96w/lqGBsqSBrzCBrDELMAkGA1UEBhMCVVMxCzAJBgNVBAgT
+AkNBMRUwEwYDVQQHEwxNb3VudGFpblZpZXcxETAPBgNVBAoTCEROQW5leHVzMRMw
+EQYDVQQLEwpPcGVyYXRpb25zMRQwEgYDVQQDEwtETkFuZXh1cyBDQTEZMBcGA1UE
+KRMQRE5BbmV4dXNQbGF0Zm9ybTEgMB4GCSqGSIb3DQEJARYRaW5mb0BkbmFuZXh1
+cy5jb22CCQCJA4llz8RTkTATBgNVHSUEDDAKBggrBgEFBQcDATALBgNVHQ8EBAMC
+BaAwDQYJKoZIhvcNAQEFBQADgYEAAqt0uP2c9VZY66apLY/vYYM2vCUWQqB0BYL0
+PCI5OeEHzGOQF8DbD4fiqNHY2NTRO4M/n+gMve6vquOCBegs/fJIf5ZoWjLaUZRm
+5PNOCO7zXt7VG3eGtq1MFfMiFD6bv7bAJCnnjtcxt6me+bxY0/QQkldxNE5pLam+
+UiqB4gc=
+</ds:X509Certificate></ds:X509Data></ds:KeyInfo><ds:Object Id="object-1"><data>
+    <!-- This comment is very important! -->
+    <country name="Liechtenstein">
+        <rank>1</rank>
+        <year>2008</year>
+        <gdppc>141100</gdppc>
+        <neighbor name="Austria" direction="E"/>
+        <neighbor name="Switzerland" direction="W"/>
+    </country>
+    <country name="Singapore">
+        <rank>4</rank>
+        <year>2011</year>
+        <gdppc>59900</gdppc>
+        <neighbor name="Malaysia" direction="N"/>
+    </country>
+    <country name="Panama">
+        <rank>68</rank>
+        <year>2011</year>
+        <gdppc>13600</gdppc>
+        <neighbor name="Costa Rica" direction="W"/>
+        <neighbor name="Colombia" direction="E"/>
+    </country>
+</data></ds:Object></ds:Signature>
+    </security>
+    <country name="Singapore">
+        <rank>4</rank>
+        <year>2011</year>
+        <gdppc>59900</gdppc>
+        <neighbor name="Malaysia" direction="N"/>
+    </country>
+    <country name="Panama">
+        <rank>68</rank>
+        <year>2011</year>
+        <gdppc>13600</gdppc>
+        <neighbor name="Costa Rica" direction="W"/>
+        <neighbor name="Colombia" direction="E"/>
+    </country>
+</data>

--- a/test/generate_125_example.py
+++ b/test/generate_125_example.py
@@ -1,0 +1,263 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os.path
+from base64 import b64encode
+
+from eight import str, bytes
+from lxml import etree
+from lxml.etree import Element, SubElement
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+from cryptography.hazmat.backends import default_backend
+
+from signxml import XMLSignatureProcessor, InvalidInput, namespaces, iterate_pem, ds_tag, _remove_sig, \
+    ensure_str, long_to_bytes, strip_pem_header, dsig11_tag
+
+
+class XMLEnvelopedEnvelopingSigner(XMLSignatureProcessor):
+    """
+    A class that signs multiple data by putting the signature enveloped in the
+    first data item, and enveloping the others.
+    """
+    def __init__(self, signature_algorithm="rsa-sha256", digest_algorithm="sha256",
+                 c14n_algorithm=XMLSignatureProcessor.default_c14n_algorithm):
+        self.sign_alg = signature_algorithm
+        assert self.sign_alg in self.known_signature_digest_tags or self.sign_alg in self.known_hmac_digest_tags
+        assert digest_algorithm in self.known_digest_tags
+        self.digest_alg = digest_algorithm
+        assert c14n_algorithm in self.known_c14n_algorithms
+        self.c14n_alg = c14n_algorithm
+        self.namespaces = dict(ds=namespaces.ds)
+        self._parser = None
+
+    def sign(self, data, key=None, passphrase=None, cert=None, key_name=None, key_info=None, id_attribute=None):
+        """
+        Sign the data and return the root element of the resulting XML tree.
+
+        :param data: Data to sign - must be a sequence of items to sign.
+        :type data_others: Sequence of String, file-like object, or XML ElementTree Element API compatible object
+        :param key:
+            Key to be used for signing. When signing with a certificate or RSA/DSA/ECDSA key, this can be a string
+            containing a PEM-formatted key, or a :py:class:`cryptography.hazmat.primitives.interfaces.RSAPublicKey`,
+            :py:class:`cryptography.hazmat.primitives.interfaces.DSAPublicKey`, or
+            :py:class:`cryptography.hazmat.primitives.interfaces.EllipticCurvePublicKey` object. When signing with a
+            HMAC, this should be a string containing the shared secret.
+        :type key:
+            string, :py:class:`cryptography.hazmat.primitives.interfaces.RSAPublicKey`,
+            :py:class:`cryptography.hazmat.primitives.interfaces.DSAPublicKey`, or
+            :py:class:`cryptography.hazmat.primitives.interfaces.EllipticCurvePublicKey` object
+        :param passphrase: Passphrase to use to decrypt the key, if any.
+        :type passphrase: string
+        :param cert:
+            X.509 certificate to use for signing. This should be a string containing a PEM-formatted certificate, or an
+            array of strings or OpenSSL.crypto.X509 objects containing the certificate and a chain of intermediate
+            certificates.
+        :type cert: string, array of strings, or array of OpenSSL.crypto.X509 objects
+        :param key_name: Add a KeyName element in the KeyInfo element that may be used by the signer to communicate a
+            key identifier to the recipient. Typically, KeyName contains an identifier related to the key pair used to
+            sign the message.
+        :type key_name: string
+        :param key_info: A custom KeyInfo element to insert in the signature. Use this to supply
+            ``<wsse:SecurityTokenReference>`` or other custom key references.
+        :type key_info: :py:class:`lxml.etree.Element`
+        :param id_attribute:
+            Name of the attribute whose value ``URI`` refers to. By default, SignXML will search for "Id", then "ID".
+        :type id_attribute: string
+
+        :returns:
+            A :py:class:`lxml.etree.Element` object representing the root of the XML tree containing the signature and
+            the payload data.
+
+        To specify the location of an enveloped signature within **data**, insert a
+        ``<ds:Signature Id="placeholder"></ds:Signature>`` element in **data** (where
+        "ds" is the "http://www.w3.org/2000/09/xmldsig#" namespace). This element will
+        be replaced by the generated signature, and excised when generating the digest.
+        """
+        if id_attribute is not None:
+            self.id_attributes = (id_attribute, )
+
+        if isinstance(cert, (str, bytes)):
+            cert_chain = list(iterate_pem(cert))
+        else:
+            cert_chain = cert
+
+        sig_root, doc_root, c14n_inputs, reference_uris = self._unpack(data)
+        signed_info_element, signature_value_element = self._build_sig(sig_root, reference_uris, c14n_inputs)
+
+        if key is None:
+            raise InvalidInput('Parameter "key" is required')
+
+        signed_info_c14n = self._c14n(signed_info_element, algorithm=self.c14n_alg)
+        if self.sign_alg.startswith("hmac-"):
+            from cryptography.hazmat.primitives.hmac import HMAC
+            signer = HMAC(key=key,
+                          algorithm=self._get_hmac_digest_method_by_tag(self.sign_alg),
+                          backend=default_backend())
+            signer.update(signed_info_c14n)
+            signature_value_element.text = ensure_str(b64encode(signer.finalize()))
+            sig_root.append(signature_value_element)
+        elif any(self.sign_alg.startswith(i) for i in ["dsa-", "rsa-", "ecdsa-"]):
+            if isinstance(key, (str, bytes)):
+                from cryptography.hazmat.primitives.serialization import load_pem_private_key
+                key = load_pem_private_key(key, password=passphrase, backend=default_backend())
+
+            hash_alg = self._get_signature_digest_method_by_tag(self.sign_alg)
+            if self.sign_alg.startswith("dsa-"):
+                signature = key.sign(signed_info_c14n, algorithm=hash_alg)
+            elif self.sign_alg.startswith("ecdsa-"):
+                signature = key.sign(signed_info_c14n, signature_algorithm=ec.ECDSA(algorithm=hash_alg))
+            elif self.sign_alg.startswith("rsa-"):
+                signature = key.sign(signed_info_c14n, padding=PKCS1v15(), algorithm=hash_alg)
+            else:
+                raise NotImplementedError()
+            if self.sign_alg.startswith("dsa-"):
+                # Note: The output of the DSA signer is a DER-encoded ASN.1 sequence of two DER integers.
+                from asn1crypto.algos import DSASignature
+                decoded_signature = DSASignature.load(signature).native
+                r = decoded_signature['r']
+                s = decoded_signature['s']
+                signature = long_to_bytes(r).rjust(32, b"\0") + long_to_bytes(s).rjust(32, b"\0")
+
+            signature_value_element.text = ensure_str(b64encode(signature))
+
+            if key_info is None:
+                key_info = SubElement(sig_root, ds_tag("KeyInfo"))
+                if key_name is not None:
+                    keyname = SubElement(key_info, ds_tag("KeyName"))
+                    keyname.text = key_name
+
+                if cert_chain is None:
+                    self._serialize_key_value(key, key_info)
+                else:
+                    x509_data = SubElement(key_info, ds_tag("X509Data"))
+                    for cert in cert_chain:
+                        x509_certificate = SubElement(x509_data, ds_tag("X509Certificate"))
+                        if isinstance(cert, (str, bytes)):
+                            x509_certificate.text = strip_pem_header(cert)
+                        else:
+                            from OpenSSL.crypto import dump_certificate, FILETYPE_PEM
+                            x509_certificate.text = strip_pem_header(dump_certificate(FILETYPE_PEM, cert))
+            else:
+                sig_root.append(key_info)
+        else:
+            raise NotImplementedError()
+
+        for c14n_input in c14n_inputs[1:]:
+            sig_root.append(c14n_input)
+        return doc_root
+
+    def _unpack(self, data):
+        sig_root = Element(ds_tag("Signature"), nsmap=self.namespaces)
+
+        if isinstance(data[0], (str, bytes)):
+            raise InvalidInput("First data item **must** be an XML element")
+
+        doc_root = self.get_root(data[0])
+
+        c14n_inputs = [self.get_root(data[0])]
+
+        signature_placeholders = self._findall(doc_root, "Signature[@Id='placeholder']", anywhere=True)
+        if len(signature_placeholders) == 0:
+            doc_root.append(sig_root)
+        elif len(signature_placeholders) == 1:
+            sig_root = signature_placeholders[0]
+            del sig_root.attrib["Id"]
+            for c14n_input in c14n_inputs:
+                placeholders = self._findall(c14n_input, "Signature[@Id='placeholder']", anywhere=True)
+                if placeholders:
+                    assert len(placeholders) == 1
+                    _remove_sig(placeholders[0])
+        else:
+            raise InvalidInput("Enveloped signature input contains more than one placeholder")
+
+        reference_uris = []
+        for c14n_input in c14n_inputs:
+            payload_id = None
+            for id_attribute in self.id_attributes:
+                payload_id = c14n_input.get(id_attribute)
+                if payload_id:
+                    break
+            reference_uris.append('#{}'.format(payload_id) if payload_id else '')
+
+        index = 1
+        for enveloped_data in data[1:]:
+            c14n_inputs.append(Element(ds_tag("Object"), nsmap=self.namespaces, Id="object-{}".format(index)))
+            if isinstance(enveloped_data, (str, bytes)):
+                c14n_inputs[index].text = enveloped_data
+            else:
+                c14n_inputs[index].append(self.get_root(enveloped_data))
+            reference_uris.append('#object-{}'.format(index))
+            index += 1
+
+        return sig_root, doc_root, c14n_inputs, reference_uris
+
+    def _build_sig(self, sig_root, reference_uris, c14n_inputs):
+        signed_info = SubElement(sig_root, ds_tag("SignedInfo"), nsmap=self.namespaces)
+        c14n_method = SubElement(signed_info, ds_tag("CanonicalizationMethod"), Algorithm=self.c14n_alg)
+        if self.sign_alg.startswith("hmac-"):
+            algorithm_id = self.known_hmac_digest_tags[self.sign_alg]
+        else:
+            algorithm_id = self.known_signature_digest_tags[self.sign_alg]
+        signature_method = SubElement(signed_info, ds_tag("SignatureMethod"), Algorithm=algorithm_id)
+        for i, reference_uri in enumerate(reference_uris):
+            reference = SubElement(signed_info, ds_tag("Reference"), URI=reference_uri)
+            if i == 0:
+                transforms = SubElement(reference, ds_tag("Transforms"))
+                SubElement(transforms, ds_tag("Transform"), Algorithm=namespaces.ds + "enveloped-signature")
+                SubElement(transforms, ds_tag("Transform"), Algorithm=self.c14n_alg)
+            digest_method = SubElement(reference, ds_tag("DigestMethod"),
+                                       Algorithm=self.known_digest_tags[self.digest_alg])
+            digest_value = SubElement(reference, ds_tag("DigestValue"))
+            payload_c14n = self._c14n(c14n_inputs[i], algorithm=self.c14n_alg)
+            digest = self._get_digest(payload_c14n, self._get_digest_method_by_tag(self.digest_alg))
+            digest_value.text = digest
+        signature_value = SubElement(sig_root, ds_tag("SignatureValue"))
+        return signed_info, signature_value
+
+    def _serialize_key_value(self, key, key_info_element):
+        key_value = SubElement(key_info_element, ds_tag("KeyValue"))
+        if self.sign_alg.startswith("rsa-"):
+            rsa_key_value = SubElement(key_value, ds_tag("RSAKeyValue"))
+            modulus = SubElement(rsa_key_value, ds_tag("Modulus"))
+            modulus.text = ensure_str(b64encode(long_to_bytes(key.public_key().public_numbers().n)))
+            exponent = SubElement(rsa_key_value, ds_tag("Exponent"))
+            exponent.text = ensure_str(b64encode(long_to_bytes(key.public_key().public_numbers().e)))
+        elif self.sign_alg.startswith("dsa-"):
+            dsa_key_value = SubElement(key_value, ds_tag("DSAKeyValue"))
+            for field in "p", "q", "g", "y":
+                e = SubElement(dsa_key_value, ds_tag(field.upper()))
+
+                if field == "y":
+                    key_params = key.public_key().public_numbers()
+                else:
+                    key_params = key.parameters().parameter_numbers()
+
+                e.text = ensure_str(b64encode(long_to_bytes(getattr(key_params, field))))
+        elif self.sign_alg.startswith("ecdsa-"):
+            ec_key_value = SubElement(key_value, dsig11_tag("ECKeyValue"), nsmap=dict(dsig11=namespaces.dsig11))
+            named_curve = SubElement(ec_key_value, dsig11_tag("NamedCurve"),
+                                     URI=self.known_ecdsa_curve_oids[key.curve.name])
+            public_key = SubElement(ec_key_value, dsig11_tag("PublicKey"))
+            x = key.public_key().public_numbers().x
+            y = key.public_key().public_numbers().y
+            public_key.text = ensure_str(b64encode(long_to_bytes(4) + long_to_bytes(x) + long_to_bytes(y)))
+
+
+if __name__ == '__main__':
+    signer = XMLEnvelopedEnvelopingSigner()
+
+    with open(os.path.join(os.path.dirname(__file__), "test", "example.pem"), "rb") as fh:
+        crt = fh.read()
+    with open(os.path.join(os.path.dirname(__file__), "test", "example.key"), "rb") as fh:
+        key = fh.read()
+
+    data = [
+        etree.parse(os.path.join(os.path.dirname(__file__), "test", "example2.xml")),
+        etree.parse(os.path.join(os.path.dirname(__file__), "test", "example.xml")),
+    ]
+
+    signed_data = signer.sign(data, key=key, cert=crt)
+    signed_data_str = etree.tostring(signed_data)
+    with open(os.path.join(os.path.dirname(__file__), "test", "example-125.xml"), "wb") as fh:
+        fh.write(signed_data_str)

--- a/test/test.py
+++ b/test/test.py
@@ -35,6 +35,17 @@ parser.resolvers.add(URIResolver())
 
 interop_dir = os.path.join(os.path.dirname(__file__), "interop")
 
+class TestVerifyXML(unittest.TestCase):
+    def test_example_multi(self):
+        with open(os.path.join(os.path.dirname(__file__), "example.pem")) as fh:
+            cert = fh.read()
+        example_file = os.path.join(os.path.dirname(__file__), "example-125.xml")
+        verify_results = XMLVerifier().verify(
+            data=etree.parse(example_file),
+            x509_cert=cert,
+            expect_references=2,
+        )
+
 class TestSignXML(unittest.TestCase):
     def setUp(self):
         self.example_xml_files = (os.path.join(os.path.dirname(__file__), "example.xml"),


### PR DESCRIPTION
This PR is my attempt at fixing issue #125.

This commit includes a few things:

 1. An `XMLSigner`-derived object to generate the test case of an XML signature that is both enveloped and enveloping;
 2. A sample signed XML file generated with the above, that triggers bug #125;
 3. A test to verify that the sample XML file can be verified successfully;
 4. My attempt at actually fixing the issue in `XMLVerifier`;

I believe part 3 could stand from being better integrated with the other tests, but I am not sure how to proceed about that.