### PR TITLE
Remove \n from certs, signature addition without ds NS

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -264,9 +264,11 @@ class XMLSigner(XMLSignatureProcessor):
         listed under the `Algorithm Identifiers and Implementation Requirements
         <http://www.w3.org/TR/xmldsig-core1/#sec-AlgID>`_ section of the XML Signature 1.1 standard are supported.
     :type digest_algorithm: string
+    :param namespaces: Namespace dictionary for the document, can be provided to override default XML signature namespaces.
+    :type namespaces: dict
     """
     def __init__(self, method=methods.enveloped, signature_algorithm="rsa-sha256", digest_algorithm="sha256",
-                 c14n_algorithm=XMLSignatureProcessor.default_c14n_algorithm):
+                 c14n_algorithm=XMLSignatureProcessor.default_c14n_algorithm, namespaces=dict(ds=namespaces.ds)):
         if method is None or method not in methods:
             raise InvalidInput("Unknown signature method {}".format(method))
         self.method = method
@@ -276,7 +278,7 @@ class XMLSigner(XMLSignatureProcessor):
         self.digest_alg = digest_algorithm
         assert c14n_algorithm in self.known_c14n_algorithms
         self.c14n_alg = c14n_algorithm
-        self.namespaces = dict(ds=namespaces.ds)
+        self.namespaces = namespaces
         self._parser = None
 
     def sign(self, data, key=None, passphrase=None, cert=None, reference_uri=None, key_name=None, key_info=None,

--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -437,14 +437,14 @@ class XMLSigner(XMLSignatureProcessor):
                 # Only sign the referenced element(s)
                 c14n_inputs, reference_uris = self._get_c14n_inputs_from_reference_uris(doc_root, reference_uris)
 
-            signature_placeholders = self._findall(doc_root, "Signature[@Id='placeholder']", anywhere=True)
+            signature_placeholders = doc_root.xpath(".//*[local-name()='Signature' and @Id='placeholder']")
             if len(signature_placeholders) == 0:
                 doc_root.append(sig_root)
             elif len(signature_placeholders) == 1:
-                sig_root = signature_placeholders[0]
-                del sig_root.attrib["Id"]
+                p = signature_placeholders[0].getparent()
+                p.replace(signature_placeholders[0], sig_root)
                 for c14n_input in c14n_inputs:
-                    placeholders = self._findall(c14n_input, "Signature[@Id='placeholder']", anywhere=True)
+                    placeholders = c14n_input.xpath(".//*[local-name()='Signature' and @Id='placeholder']")
                     if placeholders:
                         assert len(placeholders) == 1
                         _remove_sig(placeholders[0])

--- a/signxml/util/__init__.py
+++ b/signxml/util/__init__.py
@@ -98,9 +98,9 @@ pem_regexp = re.compile("{header}{nl}(.+?){footer}".format(header=PEM_HEADER, nl
 
 def strip_pem_header(cert):
     try:
-        return re.search(pem_regexp, ensure_str(cert)).group(1).replace("\r", "")
+        return re.search(pem_regexp, ensure_str(cert)).group(1).replace("\r", "").replace("\n", "")
     except Exception:
-        return ensure_str(cert).replace("\r", "")
+        return ensure_str(cert).replace("\r", "").replace("\n", "")
 
 
 def add_pem_header(bare_base64_cert):


### PR DESCRIPTION
Fixes for a few issues found when using this library to attempt some SAML attacks against a Microsoft (login.microsoft.com - Azure Active Directory) delivered SAML Response during a security assessment of a third party product consuming AAD authentication.

The Microsoft generated SAML did not use a ds namespace in the SAML request, which caused some problems when trying to re-sign messages using the same XML template. Made some changes in the code that queries the xml template to find the placeholder node to work more independently of namespaces.

Also, added code to also strip newline characters from PEM certificates.