### PR TITLE
Add support for adding Signature Properties to a detached signature

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -453,5 +453,22 @@ class TestSignXML(unittest.TestCase):
                                  expect_references=False,
                                  validate_schema=False)
 
+    def test_signature_properties_with_detached_method(self):
+        doc = etree.Element('Test', attrib={'Id': 'mytest'})
+        sigprop = etree.Element('{http://somenamespace}MyCustomProperty')
+        sigprop.text = 'Some Text'
+        with open(os.path.join(os.path.dirname(__file__), "example.key"), "rb") as file:
+            key = file.read()
+        with open(os.path.join(os.path.dirname(__file__), "example.pem"), "rb") as file:
+            cert = file.read()
+        signature = XMLSigner(method=methods.detached).sign(doc,
+                                                            cert=cert,
+                                                            key=key,
+                                                            reference_uri="#mytest",
+                                                            signature_properties=sigprop)
+        fulldoc = b'<root>' + etree.tostring(signature) + etree.tostring(doc) + b'</root>'
+        XMLVerifier().verify(etree.fromstring(fulldoc), x509_cert=cert, expect_references=2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds support for adding your own Signature Properties when you are using the detached method. This use case is relevant in, for example, the OpenADR specification, which requires a ReplayProtect element to be included in the signature.

I added a parameter `signature_properties` to the `XMLSigner.sign` method, and a helper method that builds the required SignatureProperties structure and adds it to the result.

I also added a test case for this feature.

This addresses a real-life use case in a (hopefully) non-intrusive manner.