### PR TITLE
Allow cryptography versions >3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'lxml >= 4.2.1, < 5',
         'eight >= 0.4.2, < 2',
-        'cryptography >= 2.1.4, < 3',
+        'cryptography >= 2.1.4, < 4',
         'pyOpenSSL >= 17.5.0, < 20',
         'certifi >= 2018.1.18'
     ],


### PR DESCRIPTION
This is required otherwise applications that use signxml are vulnerable to [CVE-2020-25659](https://github.com/advisories/GHSA-hggm-jpg3-v476)

The test suite passes with `cryptography==3.2.1` installed — I'm unsure what else I should check. It's not clear exactly why versions of cryptography are restricted to those <3. The [commit that set the restriction](https://github.com/XML-Security/signxml/commit/439ea916662a5ab215a9b0ee5b2a2f664dba7281) was updating dependencies to baseline on Ubuntu 18.04

