### PR TITLE
Use self.namespaces signature properties "Object" element

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -536,7 +536,7 @@ class XMLSigner(XMLSignatureProcessor):
         return signed_info, signature_value
 
     def _build_signature_properties(self, signature_properties):
-        obj = Element(ds_tag("Object"), attrib={'Id': 'prop'}, nsmap={'ds': "http://www.w3.org/2000/09/xmldsig#"})
+        obj = Element(ds_tag("Object"), attrib={'Id': 'prop'}, nsmap=self.namespaces)
         signature_properties_el = Element(ds_tag("SignatureProperties"))
         for i, el in enumerate(signature_properties):
             signature_property = Element(ds_tag("SignatureProperty"),


### PR DESCRIPTION
Instead of hard-coding the 'ds' namespace, use `self.namespaces` when constructing the signature properties `Object` element. This allows the user to add additional namespaces to the `Object` element, which is necessary if the detached signature is re-enveloped into a namespace-qualified root element.

I've added a test for this case as well.

This fixes an oversight in my earlier contribution (16060ef6851e272b87aa1909f21869563c3a5194).