### PR TITLE
Remove future imports

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from base64 import b64encode, b64decode
 from enum import Enum
 

--- a/signxml/exceptions.py
+++ b/signxml/exceptions.py
@@ -2,8 +2,6 @@
 SignXML exception types.
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import cryptography.exceptions
 
 class InvalidSignature(cryptography.exceptions.InvalidSignature):

--- a/signxml/util/__init__.py
+++ b/signxml/util/__init__.py
@@ -4,8 +4,6 @@ SignXML utility functions
 bytes_to_long, long_to_bytes copied from https://github.com/dlitz/pycrypto/blob/master/lib/Crypto/Util/number.py
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import math
 import os, sys, re, struct, textwrap
 from xml.etree import ElementTree as stdlibElementTree

--- a/test/generate_125_example.py
+++ b/test/generate_125_example.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os.path
 from base64 import b64encode
 

--- a/test/test.py
+++ b/test/test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os, sys, unittest, itertools, re
 from glob import glob
 from xml.etree import ElementTree as stdlibElementTree


### PR DESCRIPTION
Since https://github.com/XML-Security/signxml/commit/660c3b1692fb021fb4845f3a466c7b92037f1c49 support for python2 has been removed. So there is no need to keep using the `__future__` imports as such implementation is the default behaviour for python3. 