### PR TITLE
Allowing to overwrite namespace prefix ds:

### DIFF
--- a/signxml/__init__.py
+++ b/signxml/__init__.py
@@ -468,6 +468,7 @@ class XMLSigner(XMLSignatureProcessor):
                 doc_root.append(sig_root)
             elif len(signature_placeholders) == 1:
                 sig_root = signature_placeholders[0]
+                self.namespaces = sig_root.nsmap
                 del sig_root.attrib["Id"]
                 for c14n_input in c14n_inputs:
                     placeholders = self._findall(c14n_input, "Signature[@Id='placeholder']", anywhere=True)


### PR DESCRIPTION
If a placeholder for the signature is defined in the data, it's namespace map must already contain a prefix definition for "http://www.w3.org/2000/09/xmldsig#" since it wouldn't be recognised as a placeholder otherwise.
This definition is now pulled over to the signature's child elements by overwriting self.namespaces of XMLSigner.

That allows to rename the ds: prefix to something else in the created signed xml document by just defining it when the placeholder is created and it is also possible to completely suppress the namespace prefix by creating the Signature placeholder with root.SubElement('{http://www.w3.org/2000/09/xmldsig#}Signature',nsmap={None: "http://www.w3.org/2000/09/xmldsig#"}).