### PR TITLE
Import DigestAlgorithm from signxml in XAdES example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,8 +182,9 @@ SignXML supports signing and verifying documents using `XAdES <https://en.wikipe
 
 .. code-block:: python
 
+    from signxml import DigestAlgorithm
     from signxml.xades import (XAdESSigner, XAdESVerifier, XAdESVerifyResult,
-                               XAdESSignaturePolicy, XAdESDataObjectFormat, DigestAlgorithm)
+                               XAdESSignaturePolicy, XAdESDataObjectFormat)
     signature_policy = XAdESSignaturePolicy(
         Identifier="MyPolicyIdentifier",
         Description="Hello XAdES",


### PR DESCRIPTION
The documentation imports DigestAlgorithm from `signxml.xades` but the digest algorithm is not exposed there. 
So better to improve the documentation to import the algorithm from the right path. 