### PR TITLE
fix(signing): remove duplicate timezone information from `SigningTime`

### DIFF
--- a/signxml/xades/xades.py
+++ b/signxml/xades/xades.py
@@ -187,8 +187,7 @@ class XAdESSigner(XAdESProcessor, XMLSigner):
     def add_signing_time(self, signed_signature_properties, sig_root, signing_settings: SigningSettings):
         signing_time = SubElement(signed_signature_properties, xades_tag("SigningTime"), nsmap=self.namespaces)
         # TODO: make configurable
-        utc_iso_ts = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
-        signing_time.text = f"{utc_iso_ts}+00:00"
+        signing_time.text = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
 
     def add_signing_certificate(self, signed_signature_properties, sig_root, signing_settings: SigningSettings):
         # TODO: check if we need to support SigningCertificate


### PR DESCRIPTION
Fixes https://github.com/XML-Security/signxml/issues/265