### PR TITLE
fix: util.Namespace follows Attribute protocol so inspect/pytest/et al work again

### DIFF
--- a/signxml/util/__init__.py
+++ b/signxml/util/__init__.py
@@ -25,7 +25,10 @@ PEM_FOOTER = "-----END CERTIFICATE-----"
 
 class Namespace(dict):
     def __getattr__(self, a):
-        return dict.__getitem__(self, a)
+        try:
+            return dict.__getitem__(self, a)
+        except KeyError:
+            raise AttributeError(a) from None
 
 
 namespaces = Namespace(


### PR DESCRIPTION
I make use of `signxml` for SAML XML verification.

I recently tried to make `pytest` validate all my doctests, however due to `util.Namespace` not following the Attribute protocol (i.e. an override of `__getattr__`) -- on missing attributes, one should **always** raise `AttributeError` as that allows any introspection via the `inspect` module to "Just Work".

I was able to diagnose that the error was identical to https://github.com/pytest-dev/pytest/issues/5080 and that a remediation was simply catching `KeyError` and re-raising as `AttributeError`.