### PR TITLE
Align behaviour of expect_references with docs

### DIFF
--- a/signxml/verifier.py
+++ b/signxml/verifier.py
@@ -535,7 +535,11 @@ class XMLVerifier(XMLSignatureProcessor):
             msg = "Expected to find {} references, but found {}"
             raise InvalidSignature(msg.format(self.config.expect_references, len(verify_results)))
 
-        return verify_results if self.config.expect_references > 1 else verify_results[0]
+        return (
+            verify_results[0]
+            if type(self.config.expect_references) is int and self.config.expect_references == 1
+            else verify_results
+        )
 
     def _verify_reference(
         self,


### PR DESCRIPTION
Passing `expect_references=True` to `verify(...)` now results in a list of `verify_results`, irrespective of the number of references in the signature.

Fixes #278.