### PR TITLE
Set default certificate validation policy to require digitalSignature key usage

### DIFF
--- a/signxml/util/__init__.py
+++ b/signxml/util/__init__.py
@@ -228,11 +228,39 @@ class X509CertChainVerifier:
     contact SignXML maintainers.
     """
 
-    def __init__(self, ca_pem_file=None, verification_time=None):
+    @staticmethod
+    def require_digital_signature_key_usage(policy, cert, key_usage):
+        if not key_usage.digital_signature:
+            raise ValueError("certificate KeyUsage does not allow digitalSignature")
+
+    def __init__(self, ca_pem_file=None, verification_time=None, ee_policy=None, ca_policy=None):
         if ca_pem_file is None:
             ca_pem_file = certifi.where()
         self.ca_pem_file = ca_pem_file
         self.verification_time = verification_time
+
+        if ee_policy is not None:
+            if not isinstance(ee_policy, x509.verification.ExtensionPolicy):
+                raise ValueError("ee_policy must be an instance of x509.verification.ExtensionPolicy")
+            self.ee_policy = ee_policy
+        else:
+            # Set default EE extension policy that requires digitalSignature flag in keyUsage
+            self.ee_policy = (x509.verification.ExtensionPolicy
+                    .permit_all()
+                    .require_present(
+                        x509.KeyUsage,
+                        x509.verification.Criticality.AGNOSTIC,
+                        self.require_digital_signature_key_usage
+                    )
+                )
+
+        if ca_policy is not None:
+            if not isinstance(ca_policy, x509.verification.ExtensionPolicy):
+                raise ValueError("ca_policy must be an instance of x509.verification.ExtensionPolicy")
+            self.ca_policy = ca_policy
+        else:
+            # Set default CA policy
+            self.ca_policy = x509.verification.ExtensionPolicy.webpki_defaults_ca()
 
     @property
     def store(self):
@@ -244,6 +272,10 @@ class X509CertChainVerifier:
     def builder(self):
         builder = x509.verification.PolicyBuilder()
         builder = builder.store(self.store)
+        builder = builder.extension_policies(
+            ee_policy=self.ee_policy,
+            ca_policy=self.ca_policy,
+        )
         if self.verification_time is not None:
             builder = builder.time(self.verification_time)
         return builder

--- a/signxml/verifier.py
+++ b/signxml/verifier.py
@@ -257,8 +257,8 @@ class XMLVerifier(XMLSignatureProcessor):
             payload = self._c14n(payload, algorithm=self.config.default_reference_c14n_method)
         return payload
 
-    def get_cert_chain_verifier(self, ca_pem_file):
-        return X509CertChainVerifier(ca_pem_file=ca_pem_file)
+    def get_cert_chain_verifier(self, ca_pem_file, ee_policy, ca_policy):
+        return X509CertChainVerifier(ca_pem_file=ca_pem_file, ee_policy=ee_policy, ca_policy=ca_policy)
 
     def _match_key_values(self, key_value, der_encoded_key_value, signing_cert, signature_alg):
         if self.config.ignore_ambiguous_key_info is True:
@@ -309,6 +309,8 @@ class XMLVerifier(XMLSignatureProcessor):
         uri_resolver: Optional[Callable] = None,
         id_attribute: Optional[str] = None,
         expect_config: SignatureConfiguration = SignatureConfiguration(),
+        ee_policy: Optional[x509.verification.PolicyBuilder] = None,
+        ca_policy: Optional[x509.verification.PolicyBuilder] = None,
         **deprecated_kwargs,
     ) -> Union[VerifyResult, List[VerifyResult]]:
         """
@@ -383,6 +385,10 @@ class XMLVerifier(XMLSignatureProcessor):
         :param expect_config:
             Expected signature configuration. Pass a :class:`SignatureConfiguration` object to describe expected
             properties of the verified signature. Signatures with unexpected configurations will fail validation.
+        :param ee_policy:
+            Custom x509.verification.PolicyBuilder to use for validating the end-entity certificate.
+        :param ca_policy:
+            Custom x509.verification.PolicyBuilder to use for validating the CA certificate.
         :param deprecated_kwargs:
             Direct application of the parameters **require_x509**, **expect_references**, and
             **ignore_ambiguous_key_info** is deprecated. Use **expect_config** instead.
@@ -470,7 +476,9 @@ class XMLVerifier(XMLSignatureProcessor):
                 else:
                     cert_chain = [x509.load_pem_x509_certificate(add_pem_header(cert)) for cert in certs]
 
-                cert_verifier = self.get_cert_chain_verifier(ca_pem_file=ca_pem_file)
+                cert_verifier = self.get_cert_chain_verifier(
+                    ca_pem_file=ca_pem_file, ee_policy=ee_policy, ca_policy=ca_policy
+                )
 
                 signing_cert = cert_verifier.verify(cert_chain)
             elif isinstance(self.x509_cert, x509.Certificate):

--- a/test/test.py
+++ b/test/test.py
@@ -71,8 +71,8 @@ def reset_tree(t, method):
 
 def get_verifier_for_year(year: int):
     class _Verifier(XMLVerifier):
-        def get_cert_chain_verifier(self, ca_pem_file):
-            verifier = super().get_cert_chain_verifier(ca_pem_file)
+        def get_cert_chain_verifier(self, ca_pem_file, ee_policy, ca_policy):
+            verifier = super().get_cert_chain_verifier(ca_pem_file, ee_policy, ca_policy)
             verifier.verification_time = datetime(year, 1, 1)
             return verifier
 


### PR DESCRIPTION
`signxml.util.X509CertChainVerifier` currently uses the default extension policy from `x509.verification.PolicyBuilder().build_client_verifier()`, which requires the signer's certificate to have the "TLS Web Client Authentication" extended key usage extension. However, this extension is not a requirement to sign documents using XMLDSig. It should be sufficient for the signer's certificate to have only the "Digital Signature" key usage extension.

This is causing validation failures on valid XML signatures where the certificate lacks the "TLS Web Client Authentication" extended key usage extension.

This pull request:
1. Sets the default ExtensionPolicy to require only that the signer's certificate has the "Digital Signature" key usage extension.
2. Adds `ee_policy` and `ca_policy` kwargs to `XMLVerifier.verify()` to allow the ExtensionPolicy to be overridden if desired.